### PR TITLE
fix: avoid paginating on non pagination pages

### DIFF
--- a/layouts/partials/base/title.html
+++ b/layouts/partials/base/title.html
@@ -3,7 +3,7 @@
   {{- $titles = slice .Site.Title }}
 {{- end }}
 {{/* Append paginator title. The partial must be included after paginating. */}}
-{{- if not .IsPage }}
+{{- if .Store.Get "paginated" }}
   {{- with .Paginator }}
     {{- if gt .PageNumber 1 }}
       {{- $titles = $titles | append (i18n "paginator_title" .) }}


### PR DESCRIPTION
You have to explicitly indicate the page is a pagination page before including the title partial:

```html
{{ .Store.Set "paginated" true }}
{{ partial "base/title" . }}
```